### PR TITLE
Fix the standard verticle code: don't block the event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target
 .classpath
 .project
 .settings
+.idea
+*.iml
+.vertx
+

--- a/server/vertx/src/main/java/com/redhat/developers/msa/goodbye/ServerVerticle.java
+++ b/server/vertx/src/main/java/com/redhat/developers/msa/goodbye/ServerVerticle.java
@@ -16,11 +16,11 @@
  */
 package com.redhat.developers.msa.goodbye;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import io.vertx.core.AbstractVerticle;
 import io.vertx.ext.web.Router;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class ServerVerticle extends AbstractVerticle {
 
@@ -30,7 +30,15 @@ public class ServerVerticle extends AbstractVerticle {
         // Goodbye EndPoint
         router.get("/api/goodbye").handler(ctx -> ctx.response().end(goodbye()));
         // Nap  Endpoint
-        router.get("/api/nap").handler(ctx -> ctx.response().end(nap()));
+        router.get("/api/nap").handler(ctx -> {
+            vertx.<String>executeBlocking(fut -> fut.complete(nap()), false, ar -> {
+                if (ar.succeeded()) {
+                    ctx.response().end(ar.result());
+                } else {
+                    ctx.fail(ar.cause());
+                }
+            });
+        });
 
         vertx.createHttpServer().requestHandler(router::accept).listen(8080);
         System.out.println("Service running at 0.0.0.0:8080");

--- a/server/vertx/src/main/java/com/redhat/developers/msa/goodbye/readme.txt
+++ b/server/vertx/src/main/java/com/redhat/developers/msa/goodbye/readme.txt
@@ -1,8 +1,8 @@
 From this directory, use 4 event loops
-vertx run --instances 4 ServerVerticle.java
+vertx run --instances 4 -Dvertx.options.workerPoolSize=100 ServerVerticle.java
 
 OR
 
-vertx run --instances 20 ServerVerticle2.java --cluster
-vertx run --instances 180 MyWorkerVerticle.java --cluster --worker
+vertx run --instances 20 -Dvertx.options.workerPoolSize=100 ServerVerticle2.java --cluster
+vertx run --instances 180 -Dvertx.options.workerPoolSize=100 MyWorkerVerticle.java --cluster --worker
 


### PR DESCRIPTION
You can configure the worker pool size from the command line (see readme.txt)